### PR TITLE
ci(prettier): ignore CHANGELOG.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 storybook-static
 coverage
 build
+CHANGELOG.md


### PR DESCRIPTION
Auto-generated CHANGELOG was failing prettier's linter.